### PR TITLE
removed topbar, increased responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-scroll-area": "^1.2.0",
@@ -46,7 +47,7 @@
         "nodemon": "^3.0.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.13",
-        "typescript-eslint": "^8.8.1",
+        "typescript-eslint": "^8.9.0",
         "vite": "^5.0.2"
       }
     },
@@ -1547,19 +1548,6 @@
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
-    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
@@ -2014,6 +2002,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4198,17 +4222,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.8.1.tgz",
-      "integrity": "sha512-xfvdgA8AP/vxHgtgU310+WBnLB4uJQ9XdyP17RebG26rLtDrQJV3ZYrcopX91GrHmMoH8bdSwMRh2a//TiJ1jQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
+      "integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.8.1",
-        "@typescript-eslint/type-utils": "8.8.1",
-        "@typescript-eslint/utils": "8.8.1",
-        "@typescript-eslint/visitor-keys": "8.8.1",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/type-utils": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -4232,16 +4256,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.8.1.tgz",
-      "integrity": "sha512-hQUVn2Lij2NAxVFEdvIGxT9gP1tq2yM83m+by3whWFsWC+1y8pxxxHUFE1UqDu2VsGi2i6RLcv4QvouM84U+ow==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
+      "integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.8.1",
-        "@typescript-eslint/types": "8.8.1",
-        "@typescript-eslint/typescript-estree": "8.8.1",
-        "@typescript-eslint/visitor-keys": "8.8.1",
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4261,14 +4285,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.8.1.tgz",
-      "integrity": "sha512-X4JdU+66Mazev/J0gfXlcC/dV6JI37h+93W9BRYXrSn0hrE64IoWgVkO9MSJgEzoWkxONgaQpICWg8vAN74wlA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
+      "integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.1",
-        "@typescript-eslint/visitor-keys": "8.8.1"
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4279,14 +4303,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.8.1.tgz",
-      "integrity": "sha512-qSVnpcbLP8CALORf0za+vjLYj1Wp8HSoiI8zYU5tHxRVj30702Z1Yw4cLwfNKhTPWp5+P+k1pjmD5Zd1nhxiZA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
+      "integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.8.1",
-        "@typescript-eslint/utils": "8.8.1",
+        "@typescript-eslint/typescript-estree": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -4304,9 +4328,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.8.1.tgz",
-      "integrity": "sha512-WCcTP4SDXzMd23N27u66zTKMuEevH4uzU8C9jf0RO4E04yVHgQgW+r+TeVTNnO1KIfrL8ebgVVYYMMO3+jC55Q==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
+      "integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4318,14 +4342,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.8.1.tgz",
-      "integrity": "sha512-A5d1R9p+X+1js4JogdNilDuuq+EHZdsH9MjTVxXOdVFfTJXunKJR/v+fNNyO4TnoOn5HqobzfRlc70NC6HTcdg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
+      "integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.1",
-        "@typescript-eslint/visitor-keys": "8.8.1",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/visitor-keys": "8.9.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -4386,16 +4410,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.8.1.tgz",
-      "integrity": "sha512-/QkNJDbV0bdL7H7d0/y0qBbV2HTtf0TIyjSDTvvmQEzeVx8jEImEbLuOA4EsvE8gIgqMitns0ifb5uQhMj8d9w==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
+      "integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.8.1",
-        "@typescript-eslint/types": "8.8.1",
-        "@typescript-eslint/typescript-estree": "8.8.1"
+        "@typescript-eslint/scope-manager": "8.9.0",
+        "@typescript-eslint/types": "8.9.0",
+        "@typescript-eslint/typescript-estree": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4409,13 +4433,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.8.1.tgz",
-      "integrity": "sha512-0/TdC3aeRAsW7MDvYRwEc1Uwm0TIBfzjPFgg60UU2Haj5qsCs9cc3zNgY71edqE3LbWfF/WoZQd3lJoDXFQpag==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
+      "integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.8.1",
+        "@typescript-eslint/types": "8.9.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4424,19 +4448,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -5937,13 +5948,13 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
-      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6015,6 +6026,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
+      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6062,6 +6086,19 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.1.0"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
+      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -10082,15 +10119,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.8.1.tgz",
-      "integrity": "sha512-R0dsXFt6t4SAFjUSKFjMh4pXDtq04SsFKCVGDP3ZOzNP7itF0jBcZYU4fMsZr4y7O7V7Nc751dDeESbe4PbQMQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.9.0.tgz",
+      "integrity": "sha512-AuD/FXGYRQyqyOBCpNLldMlsCGvmDNxptQ3Dp58/NXeB+FqyvTfXmMyba3PYa0Vi9ybnj7G8S/yd/4Cw8y47eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.8.1",
-        "@typescript-eslint/parser": "8.8.1",
-        "@typescript-eslint/utils": "8.8.1"
+        "@typescript-eslint/eslint-plugin": "8.9.0",
+        "@typescript-eslint/parser": "8.9.0",
+        "@typescript-eslint/utils": "8.9.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.1",
+    "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-scroll-area": "^1.2.0",
@@ -47,7 +48,7 @@
     "nodemon": "^3.0.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "typescript-eslint": "^8.8.1",
+    "typescript-eslint": "^8.9.0",
     "vite": "^5.0.2"
   }
 }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect, useContext } from 'react';
-import { BrowserRouter as Router, Routes, Route, Link, useParams } from
-  'react-router-dom';
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { Bot, HeartPulse, Joystick, Menu, SlidersHorizontal, Terminal, Video } from 'lucide-react';
+import { Sheet, SheetContent, SheetTrigger } from './components/ui/sheet';
+import _ from 'lodash';
 
 import { Sidebar } from './components/sidebar';
-import { TopBar } from './components/topbar';
 import { DevicesSection } from './sections/devicessection';
 import { VideoSection } from './sections/videosection';
 import { TerminalSection } from './sections/terminalsection';
@@ -11,21 +12,50 @@ import { HealthSection } from './sections/healthsection';
 import { ConfigSection } from './sections/configsection';
 import { TeleopSection } from './sections/teleopsection';
 import { ThemeProvider } from './components/theme-provider';
-import { FleetContext, FleetContextProvider } from './components/fleetContext';
-
-import _ from 'lodash';
+import { FleetContextProvider } from './components/fleetContext';
 
 import './App.css';
+import { Button } from './components/ui/button';
 
 
-const sections = {
-  Devices: DevicesSection,
-  Video: VideoSection,
-  Teleoperation: TeleopSection,
-  Terminal: TerminalSection,
-  Health: HealthSection,
-  Configuration: ConfigSection,
-};
+const sections = [
+  {
+    name: 'Devices',
+    route: 'devices',
+    element: DevicesSection,
+    icon: <Bot />,
+  },
+  {
+    name: 'Video',
+    route: 'video',
+    element: VideoSection,
+    icon: <Video />,
+  },
+  {
+    name: 'Teleoperation',
+    route: 'teleoperation',
+    element: TeleopSection,
+    icon: <Joystick />,
+  },
+  {
+    name: 'Terminal',
+    route: 'terminal',
+    element: TerminalSection,
+    icon: <Terminal />,
+  },
+  {
+    name: 'Health',
+    route: 'health',
+    element: HealthSection,
+    icon: <HeartPulse />,
+  },
+  {
+    name: 'Configuration',
+    route: 'configuration',
+    element: ConfigSection,
+    icon: <SlidersHorizontal />,
+  },
+];
 
 
 function App() {
@@ -37,18 +67,32 @@ function App() {
           _robot-agent topics but not publish to them. We use this to get the list
           of devices. */}
         <FleetContextProvider>
-          <div className='grid h-screen grid-rows-[50px_auto] grid-cols-[300px_auto] '>
-            <TopBar />
-            <Sidebar sections={sections} />
-            <div className='overflow-y-auto p-4'>
-              <Routes>
-                { _.map(sections, (Element, section) =>
-                    <Route key={section}
-                      path={section.toLowerCase()}
-                      element={<Element />} />)
-                }
-              </Routes>
+          <div className='grid min-h-screen w-full grid-rows-[40px_auto] md:grid-rows-[auto] md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]'>
+            <Sheet>
+              <SheetTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="shrink-0 md:hidden"
+                >
+                  <Menu className="h-5 w-5" />
+                  <span className="sr-only">Toggle sections menu</span>
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="flex flex-col">
+                <Sidebar sections={sections} />
+              </SheetContent>
+            </Sheet>
+            <div className="hidden border-r bg-muted/40 md:block">
+              <Sidebar sections={sections} />
             </div>
+            <Routes>
+              { _.map(sections, (section) =>
+                  <Route key={section.name}
+                    path={section.route}
+                    element={<section.element />} />)
+              }
+            </Routes>
           </div>
         </FleetContextProvider>
       </ThemeProvider>

--- a/src/client/components/deviceselector.tsx
+++ b/src/client/components/deviceselector.tsx
@@ -7,14 +7,13 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "../components/ui/select"
+} from "./ui/select"
 
 import { FleetContext } from './fleetContext';
 
 export default function DeviceSelector({onChange}) {
   const { fleet } = useContext(FleetContext);
 
-  console.log('fleet', fleet);
   return (
     <Select onValueChange={onChange}>
       <SelectTrigger className="w-full">

--- a/src/client/components/sidebar.tsx
+++ b/src/client/components/sidebar.tsx
@@ -1,36 +1,69 @@
 import React from "react";
-import { Button } from "./ui/button"
-import { ScrollArea } from "./ui/scroll-area";
+import _ from 'lodash';
 
 import { Link, useLocation } from "react-router-dom";
+import { Button } from "./ui/button"
+import { ScrollArea } from "./ui/scroll-area";
+import { ModeToggle } from "./ui/mode-toggle";
+import { 
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "./ui/dropdown-menu";
+import { Bot, CircleUser } from "lucide-react";
 
-import _ from 'lodash';
 
 /** Creates a button linking to the provided `to` link. Highlights the button
 * when current location matches that link. */
 const PageLink = ({section}) => {
   const location = useLocation();
-  const to = `/${section.toLowerCase()}`;
-
-  return <Link to={to}>
+  const to = `/${section.route}`;
+  console.log(location.pathname, to);
+  return <Link to={to} >
     <Button
       variant={location.pathname == to ? 'secondary' : 'ghost'}
-      className="w-full justify-start font-normal"
+      className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-primary w-full"
     >
-      {section}
+      {section.icon}
+      <span className="grow text-left">{section.name}</span>
     </Button>
   </Link>;
 };
 
-export function Sidebar({sections}) {
+export function Sidebar({sections})    {
 
   return (
-    <ScrollArea className="hidden lg:block overflow-y-auto border-x-2 pt-2">
-      {
-        _.map(sections, (element, section) =>
-          <PageLink section={section} key={section} />
-        )
-      }
-    </ScrollArea>
+    <div className="flex h-full max-h-screen flex-col gap-2">
+      <div className="flex h-14 items-center border-b px-4 lg:h-[60px] lg:px-6">
+        <Link href="/" className="flex items-center gap-2 font-semibold">
+          <Bot className="h-6 w-6" />
+          <span className="">SuperRobots</span>
+        </Link>
+      </div>
+      <ScrollArea className="grow grid items-start px-2 text-sm font-medium lg:px-4">
+        {
+          _.map(sections, (section, name) =>
+            <PageLink section={section} key={name} />
+          )
+        }
+      </ScrollArea>
+      <ModeToggle/>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="secondary" size="icon" className="rounded-full ml-2 mb-2 lg:ml-4 lg:mb-4">
+            <CircleUser className="h-5 w-5" />
+            <span className="sr-only">Toggle user menu</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuLabel>My Account</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Logout</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/src/client/components/ui/mode-toggle.tsx
+++ b/src/client/components/ui/mode-toggle.tsx
@@ -16,7 +16,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" className="ml-2 mb-2 lg:ml-4">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>

--- a/src/client/components/ui/sheet.tsx
+++ b/src/client/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { Cross2Icon } from "@radix-ui/react-icons"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/client/sections/configsection.tsx
+++ b/src/client/sections/configsection.tsx
@@ -6,10 +6,21 @@ export function ConfigSection() {
   const [device, setDevice] = useState();
 
   return (
-    <div className="">
-        <DeviceSelector onChange={setDevice}/>
-        {device}
-        <JWTCapability device={device} capability={"@transitive-robotics/configuration-management"}></JWTCapability>
+    <div className="flex flex-col">
+      <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <div className="w-full flex-1">
+          <div className="relative">
+            <DeviceSelector onChange={setDevice}/>
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <div
+          className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
+        >
+          {device && <JWTCapability device={device} capability={"@transitive-robotics/configuration-management"}/>}
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/client/sections/devicessection.tsx
+++ b/src/client/sections/devicessection.tsx
@@ -1,43 +1,57 @@
 import React, { useContext } from "react";
 
 import {
-    Table,
-    TableBody,
-    TableCaption,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-  } from "../components/ui/table";
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../components/ui/table";
 
 import { FleetContext } from '../components/fleetContext';
 import _ from "lodash";
 
 export function DevicesSection() {
-    const { fleet } = useContext(FleetContext);
-    return (
-        <Table>
-        <TableCaption>Your devices</TableCaption>
-        <TableHeader>
-            <TableRow>
-            <TableHead className="w-[200px]">Name</TableHead>
-            <TableHead>Description</TableHead>
-            <TableHead className="text-right">Battery</TableHead>
-            </TableRow>
-        </TableHeader>
-        <TableBody>
-            {_.map(fleet, (device, key) => (
-            <TableRow key={key}>
-                <TableCell>
-                <div className="flex items-center gap-2">
-                    {key}
-                </div>
-                </TableCell>
-                <TableCell>no description yet</TableCell>
-                <TableCell className="text-right">100%</TableCell>
-            </TableRow>
-            ))}
-        </TableBody>
-        </Table>
-    );
+  const { fleet } = useContext(FleetContext);
+  return (
+    <div className="flex flex-col">
+      <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <div className="w-full flex-1">
+          <div className="relative">
+            Your Devices
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <div
+          className="flex flex-1 rounded-lg border border-dashed shadow-sm"
+        >
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[200px]">Name</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead className="text-right">Battery</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {_.map(fleet, (device, deviceId) => (
+                <TableRow key={deviceId}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      {device?.info?.os?.hostname || deviceId}
+                    </div>
+                  </TableCell>
+                  <TableCell>no description yet</TableCell>
+                  <TableCell className="text-right">100%</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </main>
+    </div>
+  );
 }

--- a/src/client/sections/healthsection.tsx
+++ b/src/client/sections/healthsection.tsx
@@ -6,10 +6,21 @@ export function HealthSection() {
   const [device, setDevice] = useState();
 
   return (
-    <div className="">
-        <DeviceSelector onChange={setDevice}/>
-        {device}
-        <JWTCapability device={device} capability={"@transitive-robotics/health-monitoring"} delimiters={"undefined"}></JWTCapability>
+    <div className="flex flex-col">
+      <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <div className="w-full flex-1">
+          <div className="relative">
+            <DeviceSelector onChange={setDevice}/>
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <div
+          className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
+        >
+          {device && <JWTCapability device={device} capability={"@transitive-robotics/health-monitoring"} delimiters={"undefined"}/>}
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/client/sections/teleopsection.tsx
+++ b/src/client/sections/teleopsection.tsx
@@ -6,21 +6,32 @@ export function TeleopSection() {
   const [device, setDevice] = useState();
 
   return (
-    <div className="">
-      <DeviceSelector onChange={setDevice}/>
-      {device}
-      {device && <JWTCapability
-          device={device}
-          capability={"@transitive-robotics/remote-teleop"}
-          control_rosVersion="1"
-          control_topic="/joy"
-          control_type="sensor_msgs/Joy"
-          count="1"
-          quantizer="25"
-          timeout="1800"
-          type="videotestsrc"
-          />
-      }
+    <div className="flex flex-col">
+      <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <div className="w-full flex-1">
+          <div className="relative">
+            <DeviceSelector onChange={setDevice}/>
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <div
+          className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
+        >
+          {device && <JWTCapability
+            device={device}
+            capability={"@transitive-robotics/remote-teleop"}
+            control_rosVersion="1"
+            control_topic="/joy"
+            control_type="sensor_msgs/Joy"
+            count="1"
+            quantizer="25"
+            timeout="1800"
+            type="videotestsrc"
+            />
+          }
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/client/sections/terminalsection.tsx
+++ b/src/client/sections/terminalsection.tsx
@@ -6,10 +6,21 @@ export function TerminalSection() {
   const [device, setDevice] = useState();
 
   return (
-    <div className="">
-        <DeviceSelector onChange={setDevice}/>
-        {device}
-        <JWTCapability device={device} capability={"@transitive-robotics/terminal"}></JWTCapability>
+    <div className="flex flex-col">
+      <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <div className="w-full flex-1">
+          <div className="relative">
+            <DeviceSelector onChange={setDevice}/>
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <div
+          className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
+        >
+          {device && <JWTCapability device={device} capability={"@transitive-robotics/terminal"}/>}
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/client/sections/videosection.tsx
+++ b/src/client/sections/videosection.tsx
@@ -6,17 +6,28 @@ export function VideoSection() {
   const [device, setDevice] = useState();
 
   return (
-    <div className="">
-        <DeviceSelector onChange={setDevice}/>
-        {device}
-        <JWTCapability 
+    <div className="flex flex-col">
+      <header className="flex h-14 items-center gap-4 border-b bg-muted/40 px-4 lg:h-[60px] lg:px-6">
+        <div className="w-full flex-1">
+          <div className="relative">
+            <DeviceSelector onChange={setDevice}/>
+          </div>
+        </div>
+      </header>
+      <main className="flex flex-1 flex-col gap-4 p-4 lg:gap-6 lg:p-6">
+        <div
+          className="flex flex-1 items-center justify-center rounded-lg border border-dashed shadow-sm"
+        >
+          {device && <JWTCapability 
             device={device}
             capability={"@transitive-robotics/webrtc-video"}
             count="1"
             quantizer="25"
             timeout="1800"
-            type="videotestsrc">   
-        </JWTCapability>
+            type="videotestsrc"
+          />}  
+        </div>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
Took more styling and structure from shadcn dashboard 02

- Made the sidebar responsive so it fits in a drawer for small sizes (taken from shadcn)
- There's still some more work to do to make it collapse after selecting a section
- There's more work to do to avoid repeating html structure between sections
- I placed the device selector in a kind of topbar that's present in shadcn's dashboard02, we might want to place dark/light mode toggle and user menu buttons back there since there's some place.

![image](https://github.com/user-attachments/assets/5e1e62d0-75f1-4313-a6ac-10774c1e2770)
![image](https://github.com/user-attachments/assets/5c160556-9bb3-4fcb-a1b0-970c6ee2917e)
![image](https://github.com/user-attachments/assets/b2ce7c53-1abd-4719-9e7b-27d97abde02a)
![image](https://github.com/user-attachments/assets/f3d71dbf-c769-42ef-a69a-a76e511a7d06)

closes #9 